### PR TITLE
ツールチップの表示を改善し、paramsを値で降順にソートするよう修正

### DIFF
--- a/webapp/src/components/ranking/RankingChart.vue
+++ b/webapp/src/components/ranking/RankingChart.vue
@@ -84,14 +84,15 @@ const updateChart = () => {
 
   const option = {
     textStyle: {
-      fontFamily: "'Noto Sans JP', system-ui, Avenir, Helvetica, Arial, sans-serif"
+      fontFamily: "'Noto Sans JP', system-ui, Avenir, Helvetica, Arial, sans-serif",
     },
     tooltip: {
       trigger: "axis",
       formatter: function (params: { axisValueLabel: string; color: string; seriesName: string; value: number }[]) {
         let tooltipContent = params[0].axisValueLabel + "<br/>";
-
-        params.forEach((param: { color: string; seriesName: string; value: number | null }) => {
+        // paramsをvalueの値で降順にソート
+        const sortedList = params.filter((v) => v).sort((a, b) => (b.value || 0) - (a.value || 0));
+        sortedList.forEach((param: { color: string; seriesName: string; value: number | null }) => {
           if (param.value) {
             // シリーズの色からマーカーを作成
             const colorSpan = `<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;background-color:${param.color};"></span>`;
@@ -109,8 +110,8 @@ const updateChart = () => {
       orient: "horizontal",
       bottom: 0,
       textStyle: {
-        fontFamily: "'Noto Sans JP', system-ui, Avenir, Helvetica, Arial, sans-serif"
-      }
+        fontFamily: "'Noto Sans JP', system-ui, Avenir, Helvetica, Arial, sans-serif",
+      },
     },
     grid: {
       left: "3%",


### PR DESCRIPTION
このプルリクエストは `RankingChart.vue` コンポーネントを更新し、ツールチップの機能を強化し、一貫した書式を保証します。 最も重要な変更点は、ツールチップのデータを値の降順でソートすることと、マイナーなフォーマットの問題への対処です。

### ツールチップの改善：
* ツールチップの内容をレンダリングする前に、`params` 配列を `value` プロパティで降順にソートするように `tooltip.formatter` 関数を変更しました。 これにより、最も関連性の高いデータがツールチップに最初に表示されます。

### コードフォーマット：
コードフォーマット: * 一貫したフォーマット標準に準拠するために、複数の場所で `textStyle.fontFamily` プロパティの末尾のカンマを修正しました。 [[1]](diffhunk://#diff-39c6e28d033a16cae8f754be2a90512aac93e7fc71dd8cc16f5b4cdc245a6c81L87-R95) [[2]](diffhunk://#diff-39c6e28d033a16cae8f754be2a90512aac93e7fc71dd8cc16f5b4cdc245a6c81L112-R114)
